### PR TITLE
chore: upgrade to Docker Compose v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dev": "next",
     "build": "npx prisma migrate deploy && next build",
     "start": "next start",
-    "db:up": "docker-compose up -d",
-    "db:down": "docker-compose down"
+    "db:up": "docker compose up -d",
+    "db:down": "docker compose down"
   },
   "dependencies": {
     "@next-auth/prisma-adapter": "1.0.3",


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/